### PR TITLE
feat: implement json to python conversion

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -1,0 +1,13 @@
+from typing import List, TypedDict
+
+
+class SubStruct1(TypedDict):
+    key: str
+
+
+class GeneratedStruct(TypedDict):
+    array_key: List[int]
+    boolean_key: bool
+    map_key: SubStruct1
+    number_key: int
+    string_key: str

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
                 "@commander-js/extra-typings": "^10.0.3",
                 "commander": "^10.0.0"
             },
+            "bin": {
+                "json2struct": "dist/index.js"
+            },
             "devDependencies": {
                 "@types/eslint": "^8.21.3",
                 "@types/prettier": "^2.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "json2struct",
     "version": "0.2.0",
-    "description": "CLI tool for converting JSON files into TypeScript types",
+    "description": "Tool for converting JSON to TypeScript & Python interfaces",
     "main": "dist/index.js",
     "bin": {
         "json2struct": "./dist/index.js"
@@ -14,14 +14,20 @@
         "lint": "eslint --ext \".js,.mjs,.ts,.d.ts\" --ignore-path .gitignore .",
         "test": "vitest --run",
         "test:watch": "vitest",
-        "local": "npm uninstall -g && npm install -g && json2struct"
+        "local": "npm uninstall -g && npm install -g && json2struct",
+        "example:typescript": "node dist/index.js ./examples/example.json ./examples/example.d.ts --language typescript --overwrite",
+        "example:python": "node dist/index.js ./examples/example.json ./examples/example.py --language python --overwrite"
     },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/hougesen/json2struct.git"
     },
     "keywords": [
-        "json"
+        "json",
+        "types",
+        "cli",
+        "typescript",
+        "python"
     ],
     "author": "Mads Hougesen",
     "license": "MIT",

--- a/src/__tests__/languages/python.test.ts
+++ b/src/__tests__/languages/python.test.ts
@@ -1,0 +1,198 @@
+import { expect, it, describe } from 'vitest';
+import { tokenize } from '../../tokenizer/';
+import { generatePythonStruct, convertTokenToPython } from '../../languages/python';
+
+describe('primitives', () => {
+    it('strings', () => {
+        expect(convertTokenToPython(tokenize('mads'))).toEqual('str');
+
+        expect(convertTokenToPython(tokenize('was'))).toEqual('str');
+
+        expect(convertTokenToPython(tokenize('here'))).toEqual('str');
+    });
+
+    it('numbers', () => {
+        expect(convertTokenToPython(tokenize(1))).toEqual('int');
+
+        expect(convertTokenToPython(tokenize(2))).toEqual('int');
+
+        expect(convertTokenToPython(tokenize(3))).toEqual('int');
+    });
+
+    it('floats', () => {
+        expect(convertTokenToPython(tokenize(1.2))).toEqual('float');
+
+        expect(convertTokenToPython(tokenize(3.21))).toEqual('float');
+    });
+
+    it('booleans', () => {
+        expect(convertTokenToPython(tokenize(true))).toEqual('bool');
+
+        expect(convertTokenToPython(tokenize(false))).toEqual('bool');
+    });
+
+    it('nulls', () => {
+        expect(convertTokenToPython(tokenize(null))).toEqual('None');
+    });
+});
+
+describe('arrays', () => {
+    it('empty arrays should be List[Any]', () => {
+        expect(convertTokenToPython(tokenize([]))).toEqual('List[Any]');
+    });
+
+    it('it should be possible to nest arrays', () => {
+        expect(convertTokenToPython(tokenize([[]]))).toEqual('List[List[Any]]');
+
+        expect(convertTokenToPython(tokenize([[[]]]))).toEqual('List[List[List[Any]]]');
+
+        expect(convertTokenToPython(tokenize([[['mhouge.dk']]]))).toEqual('List[List[List[str]]]');
+
+        expect(convertTokenToPython(tokenize([[[1.2]]]))).toEqual('List[List[List[float]]]');
+
+        expect(convertTokenToPython(tokenize([[[1]]]))).toEqual('List[List[List[int]]]');
+
+        expect(convertTokenToPython(tokenize([[[{}]]]))).toEqual('List[List[List[Dict[Any, Any]]]]');
+    });
+
+    it('duplicate primitives should be removed from arrays', () => {
+        expect(convertTokenToPython(tokenize(['mads', 'was', 'here']))).toEqual('List[str]');
+
+        expect(convertTokenToPython(tokenize([1, 2, 3]))).toEqual('List[int]');
+    });
+
+    it('arrays should support multiple types', () => {
+        expect(convertTokenToPython(tokenize(['mads', 1, 'mhouge.dk', 2, 3]))).toEqual('List[Union[int, str]]');
+    });
+
+    it.todo('duplicate maps should be removed from arrays', () => {
+        expect(convertTokenToPython(tokenize([{ key: 'mads' }, { key: 'was' }, { key: 'here' }]))).toEqual(
+            'Array<{ "key": string }>'
+        );
+    });
+
+    it.todo('maps should be able to be mixed in arrays', () => {
+        expect(convertTokenToPython(tokenize([{ key: 1.23 }, { key: 'mads' }, { key: 1 }]))).toEqual(
+            'Array<{ "key": number } | { "key": string }>'
+        );
+    });
+});
+
+describe('maps', () => {
+    it('empty maps should be Dict[Any, Any]', () => {
+        expect(convertTokenToPython(tokenize({}))).toEqual('Dict[Any, Any]');
+    });
+
+    it('maps should support primitive value children', () => {
+        expect(convertTokenToPython(tokenize({ key: 'value' }))).toEqual('key: str');
+
+        expect(
+            convertTokenToPython(
+                tokenize({
+                    stringKey: 'value',
+                    numberKey: 1,
+                    nullKey: null,
+                    trueKey: true,
+                    falseKey: false,
+                })
+            )
+        ).toEqual('falseKey: bool\nnullKey: None\nnumberKey: int\nstringKey: str\ntrueKey: bool');
+    });
+
+    it.todo('maps should be able to be nested', () => {
+        expect(
+            convertTokenToPython(
+                tokenize({
+                    a: {
+                        b: {
+                            c: {
+                                d: {
+                                    key: 'value',
+                                },
+                            },
+                        },
+                    },
+                })
+            )
+        ).toEqual('{ "a": { "b": { "c": { "d": { "key": string } } } } }');
+    });
+
+    it('it should be possible to mix map with arrays', () => {
+        expect(convertTokenToPython(tokenize({ arr: [1.23] }))).toEqual('arr: List[float]');
+    });
+
+    it('maps should be sorted automatically', () => {
+        expect(convertTokenToPython(tokenize({ a: 'a', b: 'b', c: 'c' }))).toEqual(
+            convertTokenToPython(tokenize({ c: 'c', b: 'b', a: 'a' }))
+        );
+    });
+});
+
+describe.todo('generatePythonStruct', () => {
+    describe('base types', () => {
+        it('only string', () => expect(generatePythonStruct(tokenize('mhouge.dk'))).toEqual('GeneratedStruct = str'));
+
+        it('only number', () => expect(generatePythonStruct(tokenize(42))).toEqual('GeneratedStruct = int'));
+
+        it('only float', () => expect(generatePythonStruct(tokenize(42.42))).toEqual('GeneratedStruct = float'));
+
+        it('only null', () => expect(generatePythonStruct(tokenize(null))).toEqual('GeneratedStruct = null'));
+
+        it('empty array', () => expect(generatePythonStruct(tokenize([]))).toEqual('GeneratedStruct = List[Any]'));
+
+        it('string array', () =>
+            expect(generatePythonStruct(tokenize(['mhouge.dk']))).toEqual('GeneratedStruct = List[str]'));
+
+        it('number array', () => expect(generatePythonStruct(tokenize([42]))).toEqual('GeneratedStruct = List[int]'));
+
+        // NOTE: should this be switched to Array<unknown>?
+        it('null array', () => expect(generatePythonStruct(tokenize([null]))).toEqual('GeneratedStruct = List[None]'));
+
+        it('empty matrix', () =>
+            expect(generatePythonStruct(tokenize([[], [], []]))).toEqual('GeneratedStruct = List[List[Any]]'));
+
+        it('mixed array', () => {
+            expect(generatePythonStruct(tokenize([1, 'mhouge.dk']))).toEqual('GeneratedStruct = List[Union[int, str]]');
+
+            expect(generatePythonStruct(tokenize([1, 'mhouge.dk', null]))).toEqual(
+                'GeneratedStruct = List[Union[None, int, str>'
+            );
+        });
+    });
+
+    describe('objects', () => {
+        it('object with only primitives', () => {
+            const jsonStr = `
+                {
+                    "tabWidth": 4,
+                    "useTabs": false,
+                    "printWidth": 120,
+                    "singleQuote": true,
+                    "semi": true
+                }`;
+
+            const expectedResult =
+                'class GeneratedStruct(TypedDict):\n  printWidth:int\n  semi: bool\n  singleQuote: bool\n  tabWidth: int\n  useTabs: bool';
+
+            expect(generatePythonStruct(tokenize(JSON.parse(jsonStr)))).toEqual(expectedResult);
+        });
+
+        it.todo('mixed record', () => {
+            const jsonStr = `
+                {
+                    "data": [
+                        {
+                            "length" : 60,
+                            "message" : "",
+                            "retry_after" : 480
+                        }
+                    ]
+                }`;
+
+            const expectedResult =
+                'type GeneratedStruct = { "data": Array<{ "length": number; "message": string; "retry_after": number }> }';
+
+            expect(generatePythonStruct(tokenize(JSON.parse(jsonStr)))).toEqual(expectedResult);
+        });
+    });
+});

--- a/src/__tests__/languages/python.test.ts
+++ b/src/__tests__/languages/python.test.ts
@@ -1,93 +1,150 @@
-import { expect, it, describe } from 'vitest';
+import { describe, expect, it } from 'vitest';
+
+import { convertTokenToPython, generatePythonStruct } from '../../languages/python';
 import { tokenize } from '../../tokenizer/';
-import { generatePythonStruct, convertTokenToPython } from '../../languages/python';
 
 describe('primitives', () => {
     it('strings', () => {
-        expect(convertTokenToPython(tokenize('mads'))).toEqual('str');
+        expect(convertTokenToPython(tokenize('mads'), new Set(), new Map())).toEqual('str');
+        expect(generatePythonStruct(tokenize('mads'))).toEqual('GeneratedStruct: str\n');
 
-        expect(convertTokenToPython(tokenize('was'))).toEqual('str');
+        expect(convertTokenToPython(tokenize('was'), new Set(), new Map())).toEqual('str');
+        expect(generatePythonStruct(tokenize('was'))).toEqual('GeneratedStruct: str\n');
 
-        expect(convertTokenToPython(tokenize('here'))).toEqual('str');
+        expect(convertTokenToPython(tokenize('here'), new Set(), new Map())).toEqual('str');
+
+        expect(generatePythonStruct(tokenize('here'))).toEqual('GeneratedStruct: str\n');
     });
 
     it('numbers', () => {
-        expect(convertTokenToPython(tokenize(1))).toEqual('int');
+        expect(convertTokenToPython(tokenize(1), new Set(), new Map())).toEqual('int');
+        expect(generatePythonStruct(tokenize(1))).toEqual('GeneratedStruct: int\n');
 
-        expect(convertTokenToPython(tokenize(2))).toEqual('int');
+        expect(convertTokenToPython(tokenize(2), new Set(), new Map())).toEqual('int');
+        expect(generatePythonStruct(tokenize(2))).toEqual('GeneratedStruct: int\n');
 
-        expect(convertTokenToPython(tokenize(3))).toEqual('int');
+        expect(convertTokenToPython(tokenize(3), new Set(), new Map())).toEqual('int');
+        expect(generatePythonStruct(tokenize(3))).toEqual('GeneratedStruct: int\n');
     });
 
     it('floats', () => {
-        expect(convertTokenToPython(tokenize(1.2))).toEqual('float');
+        expect(convertTokenToPython(tokenize(1.2), new Set(), new Map())).toEqual('float');
+        expect(generatePythonStruct(tokenize(1.2))).toEqual('GeneratedStruct: float\n');
 
-        expect(convertTokenToPython(tokenize(3.21))).toEqual('float');
+        expect(convertTokenToPython(tokenize(3.21), new Set(), new Map())).toEqual('float');
+        expect(generatePythonStruct(tokenize(3.21))).toEqual('GeneratedStruct: float\n');
     });
 
     it('booleans', () => {
-        expect(convertTokenToPython(tokenize(true))).toEqual('bool');
+        expect(convertTokenToPython(tokenize(true), new Set(), new Map())).toEqual('bool');
+        expect(generatePythonStruct(tokenize(true))).toEqual('GeneratedStruct: bool\n');
 
-        expect(convertTokenToPython(tokenize(false))).toEqual('bool');
+        expect(convertTokenToPython(tokenize(false), new Set(), new Map())).toEqual('bool');
+        expect(generatePythonStruct(tokenize(false))).toEqual('GeneratedStruct: bool\n');
     });
 
     it('nulls', () => {
-        expect(convertTokenToPython(tokenize(null))).toEqual('None');
+        expect(convertTokenToPython(tokenize(null), new Set(), new Map())).toEqual('None');
+        expect(generatePythonStruct(tokenize(null))).toEqual('GeneratedStruct: None\n');
     });
 });
 
 describe('arrays', () => {
     it('empty arrays should be List[Any]', () => {
-        expect(convertTokenToPython(tokenize([]))).toEqual('List[Any]');
+        expect(convertTokenToPython(tokenize([]), new Set(), new Map())).toEqual('List[Any]');
+        expect(generatePythonStruct(tokenize([]))).toEqual(
+            'from typing import Any, List\n\n\nGeneratedStruct: List[Any]\n'
+        );
     });
 
     it('it should be possible to nest arrays', () => {
-        expect(convertTokenToPython(tokenize([[]]))).toEqual('List[List[Any]]');
+        expect(convertTokenToPython(tokenize([[]]), new Set(), new Map())).toEqual('List[List[Any]]');
 
-        expect(convertTokenToPython(tokenize([[[]]]))).toEqual('List[List[List[Any]]]');
+        expect(convertTokenToPython(tokenize([[[]]]), new Set(), new Map())).toEqual('List[List[List[Any]]]');
 
-        expect(convertTokenToPython(tokenize([[['mhouge.dk']]]))).toEqual('List[List[List[str]]]');
+        expect(convertTokenToPython(tokenize([[['mhouge.dk']]]), new Set(), new Map())).toEqual(
+            'List[List[List[str]]]'
+        );
 
-        expect(convertTokenToPython(tokenize([[[1.2]]]))).toEqual('List[List[List[float]]]');
+        expect(convertTokenToPython(tokenize([[[1.2]]]), new Set(), new Map())).toEqual('List[List[List[float]]]');
 
-        expect(convertTokenToPython(tokenize([[[1]]]))).toEqual('List[List[List[int]]]');
+        expect(convertTokenToPython(tokenize([[[1]]]), new Set(), new Map())).toEqual('List[List[List[int]]]');
 
-        expect(convertTokenToPython(tokenize([[[{}]]]))).toEqual('List[List[List[Dict[Any, Any]]]]');
+        expect(convertTokenToPython(tokenize([[[{}]]]), new Set(), new Map())).toEqual(
+            'List[List[List[Dict[Any, Any]]]]'
+        );
     });
 
     it('duplicate primitives should be removed from arrays', () => {
-        expect(convertTokenToPython(tokenize(['mads', 'was', 'here']))).toEqual('List[str]');
+        expect(convertTokenToPython(tokenize(['mads', 'was', 'here']), new Set(), new Map())).toEqual('List[str]');
 
-        expect(convertTokenToPython(tokenize([1, 2, 3]))).toEqual('List[int]');
+        expect(generatePythonStruct(tokenize(['mads', 'was', 'here']))).toEqual(
+            'from typing import List\n\n\nGeneratedStruct: List[str]\n'
+        );
+
+        expect(convertTokenToPython(tokenize([1, 2, 3]), new Set(), new Map())).toEqual('List[int]');
+
+        expect(generatePythonStruct(tokenize([1, 2, 3]))).toEqual(
+            'from typing import List\n\n\nGeneratedStruct: List[int]\n'
+        );
     });
 
     it('arrays should support multiple types', () => {
-        expect(convertTokenToPython(tokenize(['mads', 1, 'mhouge.dk', 2, 3]))).toEqual('List[Union[int, str]]');
-    });
+        expect(convertTokenToPython(tokenize(['mads', 1, 'mhouge.dk', 2, 3]), new Set(), new Map())).toEqual(
+            'List[Union[int, str]]'
+        );
 
-    it.todo('duplicate maps should be removed from arrays', () => {
-        expect(convertTokenToPython(tokenize([{ key: 'mads' }, { key: 'was' }, { key: 'here' }]))).toEqual(
-            'Array<{ "key": string }>'
+        expect(generatePythonStruct(tokenize(['mads', 1, 'mhouge.dk', 2, 3]))).toEqual(
+            'from typing import List, Union\n\n\nGeneratedStruct: List[Union[int, str]]\n'
         );
     });
 
-    it.todo('maps should be able to be mixed in arrays', () => {
-        expect(convertTokenToPython(tokenize([{ key: 1.23 }, { key: 'mads' }, { key: 1 }]))).toEqual(
-            'Array<{ "key": number } | { "key": string }>'
+    it('duplicate maps should be removed from arrays', () => {
+        expect(
+            convertTokenToPython(tokenize([{ key: 'mads' }, { key: 'was' }, { key: 'here' }]), new Set(), new Map())
+        ).toEqual('List[SubStruct1]');
+
+        expect(generatePythonStruct(tokenize([{ key: 'mads' }, { key: 'was' }, { key: 'here' }]))).toEqual(
+            `from typing import List, TypedDict
+
+
+class SubStruct1(TypedDict):
+    key: str
+
+
+GeneratedStruct: List[SubStruct1]
+`
         );
+    });
+
+    it('maps should be able to be mixed in arrays', () => {
+        expect(
+            convertTokenToPython(tokenize([{ key: 1.23 }, { key: 'mads' }, { key: 1 }]), new Set(), new Map())
+        ).toEqual('List[Union[SubStruct1, SubStruct2, SubStruct3]]');
     });
 });
 
 describe('maps', () => {
     it('empty maps should be Dict[Any, Any]', () => {
-        expect(convertTokenToPython(tokenize({}))).toEqual('Dict[Any, Any]');
+        expect(convertTokenToPython(tokenize({}), new Set(), new Map())).toEqual('Dict[Any, Any]');
+
+        expect(generatePythonStruct(tokenize({}))).toEqual(
+            'from typing import Any, Dict\n\n\nGeneratedStruct: Dict[Any, Any]\n'
+        );
     });
 
     it('maps should support primitive value children', () => {
-        expect(convertTokenToPython(tokenize({ key: 'value' }))).toEqual('key: str');
+        expect(generatePythonStruct(tokenize({ key: 'value' }))).toEqual(
+            `from typing import TypedDict
+
+
+class GeneratedStruct(TypedDict):
+    key: str
+`
+        );
 
         expect(
-            convertTokenToPython(
+            generatePythonStruct(
                 tokenize({
                     stringKey: 'value',
                     numberKey: 1,
@@ -96,12 +153,45 @@ describe('maps', () => {
                     falseKey: false,
                 })
             )
-        ).toEqual('falseKey: bool\nnullKey: None\nnumberKey: int\nstringKey: str\ntrueKey: bool');
+        ).toEqual(
+            `from typing import TypedDict
+
+
+class GeneratedStruct(TypedDict):
+    falseKey: bool
+    nullKey: None
+    numberKey: int
+    stringKey: str
+    trueKey: bool
+`
+        );
     });
 
-    it.todo('maps should be able to be nested', () => {
+    it('maps should be able to be nested', () => {
+        const expectedResult = `from typing import TypedDict
+
+
+class SubStruct1(TypedDict):
+    key: str
+
+
+class SubStruct2(TypedDict):
+    d: SubStruct1
+
+
+class SubStruct3(TypedDict):
+    c: SubStruct2
+
+
+class SubStruct4(TypedDict):
+    b: SubStruct3
+
+
+class GeneratedStruct(TypedDict):
+    a: SubStruct4
+`;
         expect(
-            convertTokenToPython(
+            generatePythonStruct(
                 tokenize({
                     a: {
                         b: {
@@ -114,53 +204,75 @@ describe('maps', () => {
                     },
                 })
             )
-        ).toEqual('{ "a": { "b": { "c": { "d": { "key": string } } } } }');
+        ).toEqual(expectedResult);
     });
 
-    it('it should be possible to mix map with arrays', () => {
-        expect(convertTokenToPython(tokenize({ arr: [1.23] }))).toEqual('arr: List[float]');
+    it('it should be possible to mix map with arrays', async () => {
+        expect(generatePythonStruct(tokenize({ arr: [1.23] }))).toEqual(
+            'from typing import List, TypedDict\n\n\nclass GeneratedStruct(TypedDict):\n    arr: List[float]\n'
+        );
     });
 
     it('maps should be sorted automatically', () => {
-        expect(convertTokenToPython(tokenize({ a: 'a', b: 'b', c: 'c' }))).toEqual(
-            convertTokenToPython(tokenize({ c: 'c', b: 'b', a: 'a' }))
+        expect(generatePythonStruct(tokenize({ a: 'a', b: 'b', c: 'c' }))).toEqual(
+            generatePythonStruct(tokenize({ c: 'c', b: 'b', a: 'a' }))
         );
     });
 });
 
-describe.todo('generatePythonStruct', () => {
+describe('generatePythonStruct', () => {
     describe('base types', () => {
-        it('only string', () => expect(generatePythonStruct(tokenize('mhouge.dk'))).toEqual('GeneratedStruct = str'));
+        it('only string', () => expect(generatePythonStruct(tokenize('mhouge.dk'))).toEqual('GeneratedStruct: str\n'));
 
-        it('only number', () => expect(generatePythonStruct(tokenize(42))).toEqual('GeneratedStruct = int'));
+        it('only number', () => expect(generatePythonStruct(tokenize(42))).toEqual('GeneratedStruct: int\n'));
 
-        it('only float', () => expect(generatePythonStruct(tokenize(42.42))).toEqual('GeneratedStruct = float'));
+        it('only float', () => expect(generatePythonStruct(tokenize(42.42))).toEqual('GeneratedStruct: float\n'));
 
-        it('only null', () => expect(generatePythonStruct(tokenize(null))).toEqual('GeneratedStruct = null'));
+        it('only null', () => expect(generatePythonStruct(tokenize(null))).toEqual('GeneratedStruct: None\n'));
 
-        it('empty array', () => expect(generatePythonStruct(tokenize([]))).toEqual('GeneratedStruct = List[Any]'));
+        it('empty array', () =>
+            expect(generatePythonStruct(tokenize([]))).toEqual(
+                'from typing import Any, List\n\n\nGeneratedStruct: List[Any]\n'
+            ));
 
         it('string array', () =>
-            expect(generatePythonStruct(tokenize(['mhouge.dk']))).toEqual('GeneratedStruct = List[str]'));
+            expect(generatePythonStruct(tokenize(['mhouge.dk']))).toEqual(
+                'from typing import List\n\n\nGeneratedStruct: List[str]\n'
+            ));
 
-        it('number array', () => expect(generatePythonStruct(tokenize([42]))).toEqual('GeneratedStruct = List[int]'));
+        it('number array', () =>
+            expect(generatePythonStruct(tokenize([42]))).toEqual(
+                'from typing import List\n\n\nGeneratedStruct: List[int]\n'
+            ));
 
         // NOTE: should this be switched to Array<unknown>?
-        it('null array', () => expect(generatePythonStruct(tokenize([null]))).toEqual('GeneratedStruct = List[None]'));
+        it('null array', () =>
+            expect(generatePythonStruct(tokenize([null]))).toEqual(
+                'from typing import List\n\n\nGeneratedStruct: List[None]\n'
+            ));
 
         it('empty matrix', () =>
-            expect(generatePythonStruct(tokenize([[], [], []]))).toEqual('GeneratedStruct = List[List[Any]]'));
+            expect(generatePythonStruct(tokenize([[], [], []]))).toEqual(
+                'from typing import Any, List\n\n\nGeneratedStruct: List[List[Any]]\n'
+            ));
 
         it('mixed array', () => {
-            expect(generatePythonStruct(tokenize([1, 'mhouge.dk']))).toEqual('GeneratedStruct = List[Union[int, str]]');
+            expect(generatePythonStruct(tokenize([1, 'mhouge.dk']))).toEqual(
+                'from typing import List, Union\n\n\nGeneratedStruct: List[Union[int, str]]\n'
+            );
 
             expect(generatePythonStruct(tokenize([1, 'mhouge.dk', null]))).toEqual(
-                'GeneratedStruct = List[Union[None, int, str>'
+                'from typing import List, Union\n\n\nGeneratedStruct: List[Union[None, int, str]]\n'
             );
         });
     });
 
     describe('objects', () => {
+        it('empty dict', () =>
+            expect(generatePythonStruct(tokenize({}))).toEqual(
+                'from typing import Any, Dict\n\n\nGeneratedStruct: Dict[Any, Any]\n'
+            ));
+
         it('object with only primitives', () => {
             const jsonStr = `
                 {
@@ -172,12 +284,12 @@ describe.todo('generatePythonStruct', () => {
                 }`;
 
             const expectedResult =
-                'class GeneratedStruct(TypedDict):\n  printWidth:int\n  semi: bool\n  singleQuote: bool\n  tabWidth: int\n  useTabs: bool';
+                'from typing import TypedDict\n\n\nclass GeneratedStruct(TypedDict):\n    printWidth: int\n    semi: bool\n    singleQuote: bool\n    tabWidth: int\n    useTabs: bool\n';
 
             expect(generatePythonStruct(tokenize(JSON.parse(jsonStr)))).toEqual(expectedResult);
         });
 
-        it.todo('mixed record', () => {
+        it('mixed record', () => {
             const jsonStr = `
                 {
                     "data": [
@@ -189,8 +301,18 @@ describe.todo('generatePythonStruct', () => {
                     ]
                 }`;
 
-            const expectedResult =
-                'type GeneratedStruct = { "data": Array<{ "length": number; "message": string; "retry_after": number }> }';
+            const expectedResult = `from typing import List, TypedDict
+
+
+class SubStruct1(TypedDict):
+    length: int
+    message: str
+    retry_after: int
+
+
+class GeneratedStruct(TypedDict):
+    data: List[SubStruct1]
+`;
 
             expect(generatePythonStruct(tokenize(JSON.parse(jsonStr)))).toEqual(expectedResult);
         });

--- a/src/__tests__/languages/typescript.test.ts
+++ b/src/__tests__/languages/typescript.test.ts
@@ -131,8 +131,8 @@ describe('maps', () => {
     });
 });
 
-describe('json2ts', async () => {
-    describe('arrays', () => {
+describe('generateTypeScriptType', () => {
+    describe('base types', () => {
         it('only string', () =>
             expect(generateTypeScriptType(tokenize('mhouge.dk'))).toEqual('type GeneratedStruct = string'));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import fs from 'fs/promises';
 
 import { Command, Option } from '@commander-js/extra-typings';
 
+import { generatePythonStruct } from './languages/python';
 import { generateTypeScriptType } from './languages/typescript';
 import { Token, tokenize } from './tokenizer';
 
@@ -11,6 +12,9 @@ function convertToLanguage(language: string, token: Token) {
     switch (language) {
         case 'typescript':
             return generateTypeScriptType(token);
+
+        case 'python':
+            return generatePythonStruct(token);
 
         default:
             throw new Error(`${language} is not supported`);
@@ -21,7 +25,7 @@ const program = new Command();
 
 program
     .name('json2struct')
-    .description('CLI for converting JSON to TypeScript types')
+    .description('CLI for converting JSON to TypeScript & Python interfaces')
     .version('0.2.0')
     .configureOutput({
         writeOut: (str) => process.stdout.write(`[OUT] ${str}`),
@@ -33,7 +37,9 @@ program
     .command('convert <input> [output]', { isDefault: true })
     .description('Convert JSON file to type file')
     .option('--overwrite')
-    .addOption(new Option('-lang, --language <output-language>').choices(['typescript']).default('typescript'))
+    .addOption(
+        new Option('-lang, --language <output-language>').choices(['typescript', 'python']).default('typescript')
+    )
     .action(async (inputPath, outputPath, args) => {
         console.info(`\u001b[32mjson2struct: Converting ${inputPath} to ${args.language}:\u001b[0m`);
 

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -1,0 +1,79 @@
+import { Token, ArrayToken, MapToken } from '../tokenizer';
+
+type P = {
+    id: number;
+    class: boolean;
+    value: string;
+    classes: P[];
+};
+
+function convertArray(token: ArrayToken): string {
+    // NOTE: we use "List" instead of "list" since "List" is backwards compatible
+    // Users of python >= 3.9 can use list instead
+    if (!token?.children?.length) return 'List[Any]';
+
+    const children = new Set<string>();
+
+    for (let i = 0; i < token.children.length; i += 1) {
+        children.add(convertTokenToPython(token.children[i]));
+    }
+
+    const childTypesArr = Array.from(children);
+
+    if (childTypesArr.length === 1) return `List[${childTypesArr[0]}]`;
+
+    childTypesArr.sort();
+
+    return `List[Union[${childTypesArr.join(', ')}]]`;
+}
+
+function convertMap(token: MapToken): string {
+    // NOTE: we use "Dict" instead of "dict" since "Dict" is backwards compatible
+    // Users of python >= 3.9 can use dict instead
+    if (!token?.children?.length) return 'Dict[Any, Any]';
+
+    const children = new Set<string>();
+
+    for (let i = 0; i < token.children.length; i += 1) {
+        children.add(`${token.children[i].key}: ${convertTokenToPython(token.children[i])}`);
+    }
+
+    const childTypesArr = Array.from(children);
+
+    childTypesArr.sort();
+
+    return childTypesArr.join('\n');
+}
+
+export function convertTokenToPython(token: Token): string {
+    switch (token.type) {
+        case 'string':
+            return 'str';
+
+        case 'number':
+            return 'int';
+
+        case 'float':
+            return 'float';
+
+        case 'boolean':
+            return 'bool';
+
+        case 'null':
+            return 'None';
+
+        case 'array':
+            return convertArray(token);
+
+        case 'map':
+            return convertMap(token);
+
+        case 'unknown':
+        default:
+            return 'Any';
+    }
+}
+
+export function generatePythonStruct(token: Token): string {
+    return '';
+}


### PR DESCRIPTION
Implement option to convert to Python instead of TypeScript. This closes #9 