### PR TITLE
refactor: move output input to option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ The goal is for the definitions to be used as a starting point for the user, and
 The tool can either be run using npx
 
 ```sh
-$ npx json2struct <REQUIRED_INPUT_FILE> [OPTIONAL_OUTPUT_FILE]
+$ npx json2struct <REQUIRED_INPUT_FILE>
 ```
 
 or be installed globally
 
 ```sh
 $ npm i -g json2struct
-$ json2struct <REQUIRED_INPUT_FILE> [OPTIONAL_OUTPUT_FILE]
+$ json2struct <REQUIRED_INPUT_FILE>
 ```
 
 ## Usage
@@ -39,12 +39,11 @@ $ npx json2struct example.json
 
 json2struct: Converting example.json to typescript:
 type GeneratedStruct = { array_key: Array<number>; boolean_key: boolean; map_key: { key: string }; number_key: number; string_key: string }
-
 ```
 
 ### Writing struct to file
 
-To write the sturcture to a file write the output file name after the input `$ npx json2struct <REQUIRED_INPUT_FILE> [OPTIONAL_OUTPUT_FILE]`.
+To write the sturcture to a file pass use the output option `$ npx json2struct <REQUIRED_INPUT_FILE> --output <OUTPUT_FILE>`.
 
 ```sh
 # example.json
@@ -56,7 +55,7 @@ To write the sturcture to a file write the output file name after the input `$ n
     "map_key": { "key": "value" }
 }
 
-$ npx json2struct example.json example.d.ts
+$ npx json2struct example.json --output example.d.ts
 ```
 
 Writes the following to the output file:
@@ -86,7 +85,7 @@ To use another language pass the `--language` option.
     "map_key": { "key": "value" }
 }
 
-$ npx json2struct example.json example.py --language python
+$ npx json2struct example.json --output example.py --language python
 ```
 
 Writes the following to the output file:
@@ -120,7 +119,7 @@ class GeneratedStruct(TypedDict):
     "map_key": { "key": "value" }
 }
 
-$ npx json2struct example.json example.jl --language julia
+$ npx json2struct example.json --output example.jl --language julia
 ```
 
 Writes the following to the output file:
@@ -187,6 +186,10 @@ Dict[Any, Any]
 ```
 Dict{Any,Any}
 ```
+
+## Examples
+
+Examples of type definitions generated using json2struct can be found in the [examples folder](./examples/).
 
 ## Notes
 

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
         "test": "vitest --run",
         "test:watch": "vitest",
         "local": "npm uninstall -g && npm install -g && json2struct",
-        "example:typescript": "node dist/index.js ./examples/example.json ./examples/example.d.ts --language typescript --overwrite",
-        "example:python": "node dist/index.js ./examples/example.json ./examples/example.py --language python --overwrite",
-        "example:julia": "node dist/index.js ./examples/example.json ./examples/example.jl --language julia --overwrite"
+        "example:typescript": "node dist/index.js ./examples/example.json --output ./examples/example.d.ts --language typescript --overwrite",
+        "example:python": "node dist/index.js ./examples/example.json --output ./examples/example.py --language python --overwrite",
+        "example:julia": "node dist/index.js ./examples/example.json --output ./examples/example.jl --language julia --overwrite"
     },
     "repository": {
         "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,18 +38,17 @@ program
     });
 
 program
-    .command('convert <input> [output]', { isDefault: true })
+    .command('convert <input>', { isDefault: true })
     .description('Convert JSON file to type file')
+    .option('-o --output <output-file>')
     .option('--overwrite')
     .addOption(
-        new Option('-lang, --language <output-language>')
-            .choices(['typescript', 'python', 'julia'])
-            .default('typescript')
+        new Option('-l --language <output-language>').choices(['typescript', 'python', 'julia']).default('typescript')
     )
-    .action(async (inputPath, outputPath, args) => {
+    .action(async (inputPath, args) => {
         console.info(`\u001b[32mjson2struct: Converting ${inputPath} to ${args.language}:\u001b[0m`);
 
-        if (!outputPath?.length && args?.overwrite) {
+        if (!args?.output?.length && args?.overwrite) {
             program.error('--overwrite options requires an output path');
             return;
         }
@@ -62,11 +61,11 @@ program
 
         const generatedStruct = convertToLanguage(args?.language ?? 'typescript', tokens);
 
-        if (outputPath?.length) {
+        if (args.output?.length) {
             if (args?.overwrite) {
-                await fs.writeFile(outputPath, generatedStruct);
+                await fs.writeFile(args.output, generatedStruct);
             } else {
-                await fs.appendFile(outputPath, generatedStruct);
+                await fs.appendFile(args.output, generatedStruct);
             }
         }
 


### PR DESCRIPTION
Move output file argument to an option instead to support converting to languages other than TypeScript without writing to a file. 